### PR TITLE
[286] Fixed response code from 400 (Bad request) to 403 (Forbidden) in EcoNewsController [Eco-News, DELETE /econews/{econewsId}]

### DIFF
--- a/core/src/main/java/greencity/controller/EcoNewsController.java
+++ b/core/src/main/java/greencity/controller/EcoNewsController.java
@@ -8,6 +8,7 @@ import greencity.dto.econews.*;
 import greencity.dto.tag.TagDto;
 import greencity.dto.tag.TagVO;
 import greencity.dto.user.UserVO;
+import greencity.enums.Role;
 import greencity.exception.exceptions.NotFoundException;
 import greencity.service.EcoNewsService;
 import greencity.service.FileService;
@@ -243,11 +244,16 @@ public class EcoNewsController {
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = HttpStatuses.OK),
         @ApiResponse(responseCode = "401", description = HttpStatuses.UNAUTHORIZED),
+        @ApiResponse(responseCode = "403", description = HttpStatuses.FORBIDDEN),
         @ApiResponse(responseCode = "404", description = HttpStatuses.NOT_FOUND)
     })
     @DeleteMapping("/{econewsId}")
     public ResponseEntity<Object> delete(@PathVariable Long econewsId,
                                          @Parameter(hidden = true) @CurrentUser UserVO user) {
+        var ecoNews = ecoNewsService.getById(econewsId);
+        if (user.getRole() != Role.ROLE_ADMIN && ecoNews.getAuthor().getId() != user.getId()){
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+        }
         ecoNewsService.delete(econewsId, user);
         return ResponseEntity.status(HttpStatus.OK).build();
     }


### PR DESCRIPTION
[Eco-News, DELETE /econews/{econewsId}] The 400 (Bad request) response code is returned instead of 403 (Forbidden)
Environment:
Windows 11 Home
Chrome 114.0.5735.91 (Official buid) (64-bit)
GreenCityDocker-3 is built and running.

Reproducible: always.

Pre-conditions:
User is logged in as Authorized User.
There is an Econews created by another User.

Steps to reproduce

Select the “Eco-news" controller.
Select the method DELETE /econews/{econewsId} .
Set the "Id" of the econews created by another User as the value of the "econewsId' parameter'.
Send the request.
Pay attention to the response.
Actual result:
Response code 400 (Bad request) with body ({ "message": "Current user has no permission for this action"}) is returned

Expected result:
Response code 403 (Forbidden) is returned