### PR TITLE
[297] fixed not documented 400 response bug in EcoNews controller by path DELETE/econews/{econewsId}

### DIFF
--- a/core/src/main/java/greencity/controller/EcoNewsController.java
+++ b/core/src/main/java/greencity/controller/EcoNewsController.java
@@ -242,6 +242,7 @@ public class EcoNewsController {
     @Operation(summary = "Delete eco news.")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = HttpStatuses.OK),
+        @ApiResponse(responseCode = "400", description = HttpStatuses.BAD_REQUEST),
         @ApiResponse(responseCode = "401", description = HttpStatuses.UNAUTHORIZED),
         @ApiResponse(responseCode = "404", description = HttpStatuses.NOT_FOUND)
     })


### PR DESCRIPTION
[[297](https://github.com/users/OlhenShu/projects/10/views/1?pane=issue&itemId=55307740)] fixed not documented 400 response bug in EcoNews controller by path DELETE/econews/{econewsId}