### PR TITLE
[296] fixed not documented 403 response bug in EcoNews controller by path DELETE/econews/{econewsId}

### DIFF
--- a/core/src/main/java/greencity/controller/EcoNewsController.java
+++ b/core/src/main/java/greencity/controller/EcoNewsController.java
@@ -243,6 +243,7 @@ public class EcoNewsController {
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = HttpStatuses.OK),
         @ApiResponse(responseCode = "401", description = HttpStatuses.UNAUTHORIZED),
+        @ApiResponse(responseCode = "403", description = HttpStatuses.FORBIDDEN),
         @ApiResponse(responseCode = "404", description = HttpStatuses.NOT_FOUND)
     })
     @DeleteMapping("/{econewsId}")


### PR DESCRIPTION
[[296](https://github.com/users/OlhenShu/projects/10/views/1?pane=issue&itemId=55307739)] fixed not documented 403 response bug in EcoNews controller by path DELETE/econews/{econewsId}