### PR TITLE
[252] Documented response code 400 (Bad request) in CategoryController [Category, POST /category]

### DIFF
--- a/core/src/main/java/greencity/controller/CategoryController.java
+++ b/core/src/main/java/greencity/controller/CategoryController.java
@@ -31,7 +31,8 @@ public class CategoryController {
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = HttpStatuses.OK),
         @ApiResponse(responseCode = "303", description = HttpStatuses.SEE_OTHER),
-        @ApiResponse(responseCode = "401", description = HttpStatuses.UNAUTHORIZED),
+        @ApiResponse(responseCode = "400", description = HttpStatuses.BAD_REQUEST),
+        @ApiResponse(responseCode = "401", description = HttpStatuses.UNAUTHORIZED)
     })
     @PostMapping
     public ResponseEntity<CategoryDtoResponse> saveCategory(@Valid @RequestBody CategoryDto dto) {


### PR DESCRIPTION
[Category, POST /category] The response code 400 (Bad request) is not documented in the response codes list
Environment:
Windows 11 Home
Chrome 114.0.5735.91 (Official buid) (64-bit)
GreenCityDocker-3 is built and running.

Reproducible: always.

Pre-conditions:
User is logged in as Admin.
The category with the data { "name": "string2", "nameUa": "string2", "parentCategoryId": 0} is already created.

Steps to reproduce

Select “Category Controller” section.
Select the method POST/category.
Add the request body with the next data: { "name": "string2", "nameUa": "string2", "parentCategoryId": 0}
Send the request.
Compare the returned response code with the list of documented response codes.
Actual result:
Response 400 (Bad request) is not documented in the list of response codes for the method POST /category “Save category” endpoint

Expected result:
Response 400 (Bad request) is documented in the list of response codes for the method POST /category “Save category” endpoint