### PR TITLE
[319] Documented response code 400 (Bad request) in EcoNewsController [GET/econews/tags/all]

### DIFF
--- a/core/src/main/java/greencity/controller/EcoNewsController.java
+++ b/core/src/main/java/greencity/controller/EcoNewsController.java
@@ -299,6 +299,10 @@ public class EcoNewsController {
      * @author Kovaliv Taras
      */
     @Operation(summary = "Find all eco news tags")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = HttpStatuses.OK),
+            @ApiResponse(responseCode = "400", description = HttpStatuses.BAD_REQUEST)
+    })
     @GetMapping("/tags/all")
     @ApiLocale
     public ResponseEntity<List<TagDto>> findAllEcoNewsTags(@Parameter(hidden = true) @ValidLanguage Locale locale) {


### PR DESCRIPTION
[Eco-News, GET/econews/tags/all] The 400 (Bad request) response code is not documented in the response codes list.
Environment:
Windows 11 Home
Chrome 114.0.5735.91 (Official buid) (64-bit)
GreenCityDocker-3 is built and running.
Reproducible: always.

Pre-conditions:
User is not logged in.

Steps to reproduce

Select the "Eco-news" controller.
Select the method GET/econews/tags/all.
Set the PL as the value of the "lang" parameter.
Send the request.
Compare the returned response code with the list of documented response codes.
Actual result: Response code 400 (Bad request) is not documented in the response codes list.
Expected result: Response code 400 (Bad request) is documented in the response codes list.